### PR TITLE
Fade out static header on right side

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,9 @@
 # Specify the paths to include or exclude from the review
-path_filters:
-  include:
-    - "**/*" # Include all files
-  exclude: []
+reviews:
+  path_filters:
+    include:
+      - "**/*" # Include all files
+    exclude: []
 
 # Set language preferences (optional)
 language: en-US

--- a/src/components/AvatarLogo/AvatarLogo.tsx
+++ b/src/components/AvatarLogo/AvatarLogo.tsx
@@ -14,14 +14,14 @@ import styles from "./AvatarLogo.module.scss";
 
 export type AvatarLogoProps = Omit<AvatarProps, "src"> & {
   tickerDetail?: RustServiceTickerDetail;
-  alt?: string;
-  className?: string;
-  style?: React.CSSProperties;
+  title?: AvatarProps["title"];
+  className?: AvatarProps["className"];
+  style?: AvatarProps["style"];
 };
 
 export default function AvatarLogo({
   tickerDetail,
-  alt,
+  title,
   className,
   style,
   ...rest
@@ -42,7 +42,7 @@ export default function AvatarLogo({
   }
 
   if (isLoading) {
-    return <CircularProgress />;
+    return <CircularProgress style={style} className={className} />;
   }
 
   if (hasError) {
@@ -52,7 +52,7 @@ export default function AvatarLogo({
   return (
     <Avatar
       {...rest}
-      alt={alt || `${tickerDetail.symbol} logo`}
+      title={title || `${tickerDetail.symbol} logo`}
       src={base64 ? `data:image/png;base64,${base64}` : noImageAvailable}
       className={clsx(styles.avatar_logo, className)}
       style={mergedStyle}

--- a/src/components/EncodedImage/EncodedImage.tsx
+++ b/src/components/EncodedImage/EncodedImage.tsx
@@ -9,20 +9,22 @@ import useEncodedImage from "@hooks/useEncodedImage";
 
 export type EncodedImageProps = React.HTMLAttributes<HTMLImageElement> & {
   encSrc?: string;
-  alt?: string;
-  className?: string;
+  title?: React.HTMLAttributes<HTMLImageElement>["title"];
+  className?: React.HTMLAttributes<HTMLImageElement>["className"];
+  style?: React.HTMLAttributes<HTMLImageElement>["style"];
 };
 
 export default function EncodedImage({
   encSrc,
-  alt = "Encoded Image",
+  title = "Encoded Image",
   className,
+  style,
   ...rest
 }: EncodedImageProps) {
   const { isLoading, base64, hasError } = useEncodedImage(encSrc);
 
   if (isLoading) {
-    return <CircularProgress />;
+    return <CircularProgress style={style} className={className} />;
   }
 
   if (hasError) {
@@ -32,8 +34,9 @@ export default function EncodedImage({
   return (
     <img
       src={base64 ? `data:image/png;base64,${base64}` : noImageAvailable}
-      alt={alt}
+      title={title}
       className={className}
+      style={style}
       {...rest}
     />
   );

--- a/src/components/TickerDetail/TickerDetail.Header.Static.tsx
+++ b/src/components/TickerDetail/TickerDetail.Header.Static.tsx
@@ -4,9 +4,9 @@ import { Box, ButtonBase } from "@mui/material";
 
 import type { RustServiceTickerDetail } from "@src/types";
 
-import useURLState from "@hooks/useURLState";
+import AvatarLogo from "@components/AvatarLogo";
 
-import EncodedImage from "../EncodedImage";
+import useURLState from "@hooks/useURLState";
 
 export type TickerDetailStaticHeaderProps = {
   tickerDetail: RustServiceTickerDetail;
@@ -47,15 +47,9 @@ export default function TickerDetailStaticHeader({
           )
         }
       >
-        {
-          // TODO: Replace w/ AvatarLogo
-        }
-        <EncodedImage
-          encSrc={tickerDetail?.logo_filename}
-          title={`${tickerDetail?.symbol} logo`}
+        <AvatarLogo
+          tickerDetail={tickerDetail}
           style={{
-            width: 40,
-            height: 40,
             verticalAlign: "middle",
             marginRight: 8,
             flexShrink: 0,

--- a/src/components/TickerDetail/TickerDetail.Header.Static.tsx
+++ b/src/components/TickerDetail/TickerDetail.Header.Static.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+
+import { Box, ButtonBase } from "@mui/material";
+
+import type { RustServiceTickerDetail } from "@src/types";
+
+import useURLState from "@hooks/useURLState";
+
+import EncodedImage from "../EncodedImage";
+
+export type TickerDetailStaticHeaderProps = {
+  tickerDetail: RustServiceTickerDetail;
+};
+
+export default function TickerDetailStaticHeader({
+  tickerDetail,
+}: TickerDetailStaticHeaderProps) {
+  const { setURLState, toBooleanParam } = useURLState();
+
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        width: "100%",
+        // Apply a gradient fade-out so the static header doesn't appear to overlay the scrollbar
+        backgroundImage:
+          "linear-gradient(to right, rgba(0,0,0,.7) 80%, rgba(0,0,0,0) 100%)",
+        padding: 1,
+        zIndex: 1000,
+        display: "flex",
+        alignItems: "center",
+        overflow: "hidden",
+      }}
+    >
+      <ButtonBase
+        sx={{ width: "100%", overflow: "hidden" }}
+        onClick={() =>
+          setURLState(
+            {
+              query: tickerDetail.symbol,
+              exact: toBooleanParam(true),
+            },
+            false,
+            "/search",
+          )
+        }
+      >
+        {
+          // TODO: Replace w/ AvatarLogo
+        }
+        <EncodedImage
+          encSrc={tickerDetail?.logo_filename}
+          title={`${tickerDetail?.symbol} logo`}
+          style={{
+            width: 40,
+            height: 40,
+            verticalAlign: "middle",
+            marginRight: 8,
+            flexShrink: 0,
+          }}
+        />
+        <h3
+          style={{
+            display: "inline-block",
+            textAlign: "left",
+            margin: 0,
+            padding: 0,
+            whiteSpace: "nowrap", // Prevent text from wrapping to the next line
+            overflow: "hidden", // Hide overflowing content
+            textOverflow: "ellipsis", // Show ellipsis for overflowing text
+            flexGrow: 1, // Allow the text to take up available space
+          }}
+        >
+          {tickerDetail.company_name}
+        </h3>
+      </ButtonBase>
+    </Box>
+  );
+}

--- a/src/components/TickerDetail/TickerDetail.Header.tsx
+++ b/src/components/TickerDetail/TickerDetail.Header.tsx
@@ -17,6 +17,7 @@ import useURLState from "@hooks/useURLState";
 import formatCurrency from "@utils/formatCurrency";
 
 import EncodedImage from "../EncodedImage";
+import TickerDetailStaticHeader from "./TickerDetail.Header.Static";
 
 export type TickerDetailProps = React.HTMLAttributes<HTMLDivElement> & {
   tickerId: number;
@@ -49,62 +50,7 @@ export default function TickerDetailHeader({
   return (
     <>
       {isShowingStaticHeader && (
-        <Box
-          sx={{
-            position: "fixed",
-            top: 0,
-            left: 0,
-            width: "100%",
-            // Apply a gradient fade-out so the static header doesn't appear to overlay the scrollbar
-            backgroundImage:
-              "linear-gradient(to right, rgba(0,0,0,.7) 80%, rgba(0,0,0,0) 100%)",
-            padding: 1,
-            zIndex: 1000,
-            display: "flex",
-            alignItems: "center",
-            overflow: "hidden",
-          }}
-        >
-          <ButtonBase
-            sx={{ width: "100%", overflow: "hidden" }}
-            onClick={() =>
-              setURLState(
-                {
-                  query: tickerDetail.symbol,
-                  exact: toBooleanParam(true),
-                },
-                false,
-                "/search",
-              )
-            }
-          >
-            <EncodedImage
-              encSrc={tickerDetail?.logo_filename}
-              title={`${tickerDetail?.symbol} logo`}
-              style={{
-                width: 40,
-                height: 40,
-                verticalAlign: "middle",
-                marginRight: 8,
-                flexShrink: 0,
-              }}
-            />
-            <h3
-              style={{
-                display: "inline-block",
-                textAlign: "left",
-                margin: 0,
-                padding: 0,
-                whiteSpace: "nowrap", // Prevent text from wrapping to the next line
-                overflow: "hidden", // Hide overflowing content
-                textOverflow: "ellipsis", // Show ellipsis for overflowing text
-                flexGrow: 1, // Allow the text to take up available space
-              }}
-            >
-              {tickerDetail.company_name}
-            </h3>
-          </ButtonBase>
-        </Box>
+        <TickerDetailStaticHeader tickerDetail={tickerDetail} />
       )}
       <SymbolDetailWrapper ref={elRef}>
         <LogoContainer

--- a/src/components/TickerDetail/TickerDetail.Header.tsx
+++ b/src/components/TickerDetail/TickerDetail.Header.tsx
@@ -55,7 +55,9 @@ export default function TickerDetailHeader({
             top: 0,
             left: 0,
             width: "100%",
-            backgroundColor: "rgba(0,0,0,.7)",
+            // Apply a gradient fade-out so the static header doesn't appear to overlay the scrollbar
+            backgroundImage:
+              "linear-gradient(to right, rgba(0,0,0,.7) 80%, rgba(0,0,0,0) 100%)",
             padding: 1,
             zIndex: 1000,
             display: "flex",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a `title` prop for the `AvatarLogo` and `EncodedImage` components, replacing the previous `alt` prop for improved accessibility and user experience.
  - Added a new `TickerDetailStaticHeader` component to enhance the ticker detail view with a static header, improving navigation and visual appeal.

- **Bug Fixes**
  - Refactored the internal logic of the `TickerDetail.Header` to simplify rendering and improve modularity.

- **Improvements**
  - Enhanced customization options for the `CircularProgress` component by allowing `style` and `className` props.
  - Improved layout and responsiveness of the new `TickerDetailStaticHeader` component, ensuring content displays appropriately.
  - Clarified configuration structure in `.coderabbit.yaml` for better management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->