### PR TITLE
Add `recently viewed` in search

### DIFF
--- a/src/components/BucketManager/TickerQuantityFields/TickerQuantityFields.tsx
+++ b/src/components/BucketManager/TickerQuantityFields/TickerQuantityFields.tsx
@@ -141,32 +141,41 @@ export default function TickerQuantityFields({
     <Container maxWidth="md">
       <Box sx={{ my: 4 }}>
         <Grid container spacing={3}>
-          {existingTickers.map((bucketTicker, idx) => (
-            <TickerQuantityFieldsItem
-              key={bucketTicker?.tickerId || idx}
-              initialBucketTicker={bucketTicker}
-              existingBucketTickers={existingTickers}
-              onUpdate={(updatedTicker: TickerBucketTicker | null) =>
-                handleUpdateField(updatedTicker)
-              }
-              onDelete={() => handleRemoveField(bucketTicker.tickerId)}
-              onErrorStateChange={(hasError) =>
-                handleErrorStateChange(bucketTicker?.tickerId || idx, hasError)
-              }
-              omitShares={omitShares}
-            />
-          ))}
-          {newTicker && (
-            <TickerQuantityFieldsItem
-              existingBucketTickers={existingTickers}
-              onUpdate={handleUpdateField}
-              onCancel={handleRemoveNewTickerFields}
-              onErrorStateChange={(hasError) =>
-                handleErrorStateChange(newTicker.tickerId || "new", hasError)
-              }
-              omitShares={omitShares}
-            />
-          )}
+          {
+            // Render existing form fields from the tickerBucket or newly added ones
+            existingTickers.map((bucketTicker, idx) => (
+              <TickerQuantityFieldsItem
+                key={bucketTicker?.tickerId || idx}
+                initialBucketTicker={bucketTicker}
+                existingBucketTickers={existingTickers}
+                onUpdate={(updatedTicker: TickerBucketTicker | null) =>
+                  handleUpdateField(updatedTicker)
+                }
+                onDelete={() => handleRemoveField(bucketTicker.tickerId)}
+                onErrorStateChange={(hasError) =>
+                  handleErrorStateChange(
+                    bucketTicker?.tickerId || idx,
+                    hasError,
+                  )
+                }
+                omitShares={omitShares}
+              />
+            ))
+          }
+          {
+            // Render the new form field if a new ticker is being added
+            newTicker && (
+              <TickerQuantityFieldsItem
+                existingBucketTickers={existingTickers}
+                onUpdate={handleUpdateField}
+                onCancel={handleRemoveNewTickerFields}
+                onErrorStateChange={(hasError) =>
+                  handleErrorStateChange(newTicker.tickerId || "new", hasError)
+                }
+                omitShares={omitShares}
+              />
+            )
+          }
           <Grid item xs={12}>
             <Button
               variant="contained"

--- a/src/components/TickerSearchModal/TickerSearchModal.tsx
+++ b/src/components/TickerSearchModal/TickerSearchModal.tsx
@@ -323,7 +323,7 @@ export default function TickerSearchModal({
         )}
       </Box>
       <DialogActions>
-        {totalSearchResults > 0 && (
+        {searchQuery.trim() && totalSearchResults > 0 && (
           <div
             style={{
               fontStyle: "italic",

--- a/src/components/TickerSearchModal/TickerSearchModal.tsx
+++ b/src/components/TickerSearchModal/TickerSearchModal.tsx
@@ -28,10 +28,11 @@ import DialogModal, { DialogModalProps } from "@components/DialogModal";
 import EncodedImage from "@components/EncodedImage";
 
 import useStableCurrentRef from "@hooks/useStableCurrentRef";
-import useTickerSearch from "@hooks/useTickerSearch";
 
 import { RustServiceTickerSearchResult } from "@utils/callRustService";
 import customLogger from "@utils/customLogger";
+
+import useTickerSearchModalContent from "./useTickerSearchModalContent";
 
 export type TickerSearchModalProps = Omit<DialogModalProps, "children"> & {
   onSelectSearchQuery?: (searchQuery: string, isExact: boolean) => void;
@@ -80,9 +81,7 @@ export default function TickerSearchModal({
     setPage,
     pageSize,
     totalPages,
-  } = useTickerSearch({
-    initialPageSize: 10,
-  });
+  } = useTickerSearchModalContent();
 
   const handleCancel = useCallback(() => {
     try {

--- a/src/components/TickerSearchModal/TickerSearchModal.tsx
+++ b/src/components/TickerSearchModal/TickerSearchModal.tsx
@@ -81,7 +81,9 @@ export default function TickerSearchModal({
     setPage,
     pageSize,
     totalPages,
-  } = useTickerSearchModalContent();
+  } = useTickerSearchModalContent({
+    isSearchModalOpen: isOpen,
+  });
 
   const handleCancel = useCallback(() => {
     try {

--- a/src/components/TickerSearchModal/TickerSearchModal.tsx
+++ b/src/components/TickerSearchModal/TickerSearchModal.tsx
@@ -303,7 +303,7 @@ export default function TickerSearchModal({
       </DialogContent>
       {
         // FIXME: This box should technically be inside of `DialogActions` but
-        // the overall UI layout is perfect here.
+        // the overall UI layout is decent here.
         //
         // TODO: On very small viewports, move the pagination into the scroll body.
       }

--- a/src/components/TickerSearchModal/TickerSearchModal.tsx
+++ b/src/components/TickerSearchModal/TickerSearchModal.tsx
@@ -24,14 +24,14 @@ import {
   Typography,
 } from "@mui/material";
 
-import useSearch from "@hooks/useSearch";
+import DialogModal, { DialogModalProps } from "@components/DialogModal";
+import EncodedImage from "@components/EncodedImage";
+
 import useStableCurrentRef from "@hooks/useStableCurrentRef";
+import useTickerSearch from "@hooks/useTickerSearch";
 
 import { RustServiceTickerSearchResult } from "@utils/callRustService";
 import customLogger from "@utils/customLogger";
-
-import DialogModal, { DialogModalProps } from "./DialogModal";
-import EncodedImage from "./EncodedImage";
 
 export type TickerSearchModalProps = Omit<DialogModalProps, "children"> & {
   onSelectSearchQuery?: (searchQuery: string, isExact: boolean) => void;
@@ -80,7 +80,7 @@ export default function TickerSearchModal({
     setPage,
     pageSize,
     totalPages,
-  } = useSearch({
+  } = useTickerSearch({
     initialPageSize: 10,
   });
 

--- a/src/components/TickerSearchModal/TickerSearchModal.tsx
+++ b/src/components/TickerSearchModal/TickerSearchModal.tsx
@@ -81,6 +81,7 @@ export default function TickerSearchModal({
     setPage,
     pageSize,
     totalPages,
+    resultsMode,
   } = useTickerSearchModalContent({
     isSearchModalOpen: isOpen,
   });
@@ -249,6 +250,18 @@ export default function TickerSearchModal({
           overflowY: "auto",
         }}
       >
+        {searchResults.length > 0 && (
+          <Typography
+            variant="body2"
+            sx={{ fontStyle: "italic", opacity: 0.5 }}
+          >
+            {resultsMode == "recently_viewed" &&
+              `Recently viewed result${searchResults.length !== 1 ? "s" : ""}`}
+            {resultsMode == "ticker_tape" &&
+              `Result${searchResults.length !== 1 ? "s" : ""} from Ticker Tape`}
+          </Typography>
+        )}
+
         <List>
           {searchResults.map((searchResult, idx) => (
             <ButtonBase

--- a/src/components/TickerSearchModal/index.tsx
+++ b/src/components/TickerSearchModal/index.tsx
@@ -1,0 +1,4 @@
+import TickerSearchModal, { TickerSearchModalProps } from "./TickerSearchModal";
+
+export default TickerSearchModal;
+export type { TickerSearchModalProps };

--- a/src/components/TickerSearchModal/useTickerSearchModalContent.ts
+++ b/src/components/TickerSearchModal/useTickerSearchModalContent.ts
@@ -1,0 +1,33 @@
+import useTickerSearch from "@hooks/useTickerSearch";
+
+export default function useTickerSearchModalContent() {
+  const {
+    searchQuery,
+    setSearchQuery,
+    searchResults,
+    setSelectedIndex,
+    selectedIndex,
+    totalSearchResults,
+    page,
+    setPage,
+    pageSize,
+    totalPages,
+  } = useTickerSearch({
+    initialPageSize: 10,
+  });
+
+  // TODO: If no search results, show most recently viewed
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    searchResults,
+    setSelectedIndex,
+    selectedIndex,
+    totalSearchResults,
+    page,
+    setPage,
+    pageSize,
+    totalPages,
+  };
+}

--- a/src/components/TickerSearchModal/useTickerSearchModalContent.ts
+++ b/src/components/TickerSearchModal/useTickerSearchModalContent.ts
@@ -33,10 +33,10 @@ type TickerSearchModalResultsResponse = {
 export default function useTickerSearchModalContent({
   isSearchModalOpen,
 }: TickerSearchModalContentProps): TickerSearchModalResultsResponse {
-  const [recentlyViewedSearchResults, setRecentlyViewedSearchResults] =
-    useState<RustServiceTickerSearchResult[]>([]);
-  const [recentlyViewedSelectedIndex, setRecentlyViewedSelectedIndex] =
-    useState<number>(-1);
+  const [altSearchResults, setAltSearchResults] = useState<
+    RustServiceTickerSearchResult[]
+  >([]);
+  const [altSelectedIndex, setAltSelectedIndex] = useState<number>(-1);
 
   const [resultsMode, setResultsMode] = useState<TickerSearchModalResultsMode>(
     "ticker_search_results",
@@ -78,7 +78,7 @@ export default function useTickerSearchModalContent({
           .filter((result) => result.status === "fulfilled")
           .map((result) => result.value);
 
-        const recentlyViewedSearchResults: RustServiceTickerSearchResult[] =
+        const altSearchResults: RustServiceTickerSearchResult[] =
           fulfilledDetails.map((tickerDetail) => ({
             ticker_id: tickerDetail.ticker_id,
             symbol: tickerDetail.symbol,
@@ -87,11 +87,11 @@ export default function useTickerSearchModalContent({
             logo_filename: tickerDetail.logo_filename,
           }));
 
-        setRecentlyViewedSearchResults(recentlyViewedSearchResults);
+        setAltSearchResults(altSearchResults);
       });
     } else {
       // Reset selected index
-      setRecentlyViewedSelectedIndex(-1);
+      setAltSelectedIndex(-1);
 
       setResultsMode("ticker_search_results");
     }
@@ -116,13 +116,13 @@ export default function useTickerSearchModalContent({
     if (resultsMode !== "ticker_search_results") {
       return {
         ...common,
-        searchResults: recentlyViewedSearchResults,
-        setSelectedIndex: setRecentlyViewedSelectedIndex,
-        selectedIndex: recentlyViewedSelectedIndex,
-        totalSearchResults: recentlyViewedSearchResults.length,
+        searchResults: altSearchResults,
+        setSelectedIndex: setAltSelectedIndex,
+        selectedIndex: altSelectedIndex,
+        totalSearchResults: altSearchResults.length,
         page: 1,
         setPage: () => {}, // no-op
-        pageSize: recentlyViewedSearchResults.length,
+        pageSize: altSearchResults.length,
         totalPages: 1,
       };
     }
@@ -141,6 +141,7 @@ export default function useTickerSearchModalContent({
   }, [
     tickerSearchQuery,
     setTickerSearchQuery,
+    resultsMode,
     tickerSearchResults,
     setTickerSearchSelectedIndex,
     tickerSearchSelectedIndex,
@@ -149,9 +150,8 @@ export default function useTickerSearchModalContent({
     setTickerResultsPage,
     setTickerResultsPageSize,
     totalTickerResultsPages,
-    recentlyViewedSearchResults,
-    recentlyViewedSelectedIndex,
-    resultsMode,
+    altSearchResults,
+    altSelectedIndex,
   ]);
 
   return {

--- a/src/components/TickerSearchModal/useTickerSearchModalContent.ts
+++ b/src/components/TickerSearchModal/useTickerSearchModalContent.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
 
 import store from "@src/store";
 
@@ -11,9 +11,27 @@ export type TickerSearchModalContentProps = {
   isSearchModalOpen: boolean;
 };
 
+// TODO: Rename accordingly
+type TickerSearchModalResultsMode = "ticker-search-results" | "bucket-view";
+
+// TODO: Rename accordingly
+type TickerSearchModalContentResponse = {
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  searchResults: RustServiceTickerSearchResult[];
+  setSelectedIndex: Dispatch<SetStateAction<number>>;
+  selectedIndex: number;
+  totalSearchResults: number;
+  page: number;
+  setPage: (page: number) => void;
+  pageSize: number;
+  totalPages: number;
+  resultsMode: TickerSearchModalResultsMode;
+};
+
 export default function useTickerSearchModalContent({
   isSearchModalOpen,
-}: TickerSearchModalContentProps) {
+}: TickerSearchModalContentProps): TickerSearchModalContentResponse {
   const [recentlyViewedSearchResults, setRecentlyViewedSearchResults] =
     useState<RustServiceTickerSearchResult[]>([]);
   const [recentlyViewedSelectedIndex, setRecentlyViewedSelectedIndex] =
@@ -80,21 +98,30 @@ export default function useTickerSearchModalContent({
     setPage,
     pageSize,
     totalPages,
-  } = useMemo(() => {
+    resultsMode,
+  } = useMemo<TickerSearchModalContentResponse>(() => {
+    const common = {
+      searchQuery: tickerSearchQuery,
+      setSearchQuery: setTickerSearchQuery,
+    };
+
     if (!tickerSearchQuery.trim().length) {
       return {
+        ...common,
         searchResults: recentlyViewedSearchResults,
         setSelectedIndex: setRecentlyViewedSelectedIndex,
         selectedIndex: recentlyViewedSelectedIndex,
         totalSearchResults: recentlyViewedSearchResults.length,
         page: 1,
-        setPage: () => null,
+        setPage: () => {}, // no-op
         pageSize: recentlyViewedSearchResults.length,
         totalPages: 1,
+        resultsMode: "bucket-view",
       };
     }
 
     return {
+      ...common,
       searchResults: tickerSearchResults,
       setSelectedIndex: setTickerSearchSelectedIndex,
       selectedIndex: tickerSearchSelectedIndex,
@@ -103,9 +130,11 @@ export default function useTickerSearchModalContent({
       setPage: setTickerResultsPage,
       pageSize: setTickerResultsPageSize,
       totalPages: totalTickerResultsPages,
+      resultsMode: "ticker-search-results",
     };
   }, [
     tickerSearchQuery,
+    setTickerSearchQuery,
     tickerSearchResults,
     setTickerSearchSelectedIndex,
     tickerSearchSelectedIndex,
@@ -118,8 +147,6 @@ export default function useTickerSearchModalContent({
     recentlyViewedSelectedIndex,
   ]);
 
-  // TODO: Also return `mode` to show which type of results are being used
-
   return {
     searchQuery: tickerSearchQuery,
     setSearchQuery: setTickerSearchQuery,
@@ -131,5 +158,6 @@ export default function useTickerSearchModalContent({
     setPage,
     pageSize,
     totalPages,
+    resultsMode,
   };
 }

--- a/src/components/TickerSearchModal/useTickerSearchModalContent.ts
+++ b/src/components/TickerSearchModal/useTickerSearchModalContent.ts
@@ -11,8 +11,10 @@ export type TickerSearchModalContentProps = {
   isSearchModalOpen: boolean;
 };
 
-// TODO: Rename accordingly
-type TickerSearchModalResultsMode = "ticker-search-results" | "bucket-view";
+type TickerSearchModalResultsMode =
+  | "ticker_search_results"
+  | "recently_viewed"
+  | "ticker_tape";
 
 type TickerSearchModalResultsResponse = {
   searchQuery: string;
@@ -36,6 +38,10 @@ export default function useTickerSearchModalContent({
   const [recentlyViewedSelectedIndex, setRecentlyViewedSelectedIndex] =
     useState<number>(-1);
 
+  const [resultsMode, setResultsMode] = useState<TickerSearchModalResultsMode>(
+    "ticker_search_results",
+  );
+
   const {
     searchQuery: tickerSearchQuery,
     setSearchQuery: setTickerSearchQuery,
@@ -56,6 +62,8 @@ export default function useTickerSearchModalContent({
     if (isSearchModalOpen && !tickerSearchQuery.trim().length) {
       const recentlyViewed =
         store.getFirstTickerBucketOfType("recently_viewed");
+
+      setResultsMode("recently_viewed");
 
       const resultsPromise =
         recentlyViewed?.tickers &&
@@ -84,6 +92,8 @@ export default function useTickerSearchModalContent({
     } else {
       // Reset selected index
       setRecentlyViewedSelectedIndex(-1);
+
+      setResultsMode("ticker_search_results");
     }
   }, [isSearchModalOpen, tickerSearchQuery]);
 
@@ -97,14 +107,13 @@ export default function useTickerSearchModalContent({
     setPage,
     pageSize,
     totalPages,
-    resultsMode,
-  } = useMemo<TickerSearchModalResultsResponse>(() => {
+  } = useMemo<Omit<TickerSearchModalResultsResponse, "resultsMode">>(() => {
     const common = {
       searchQuery: tickerSearchQuery,
       setSearchQuery: setTickerSearchQuery,
     };
 
-    if (!tickerSearchQuery.trim().length) {
+    if (resultsMode !== "ticker_search_results") {
       return {
         ...common,
         searchResults: recentlyViewedSearchResults,
@@ -115,7 +124,6 @@ export default function useTickerSearchModalContent({
         setPage: () => {}, // no-op
         pageSize: recentlyViewedSearchResults.length,
         totalPages: 1,
-        resultsMode: "bucket-view",
       };
     }
 
@@ -129,7 +137,6 @@ export default function useTickerSearchModalContent({
       setPage: setTickerResultsPage,
       pageSize: setTickerResultsPageSize,
       totalPages: totalTickerResultsPages,
-      resultsMode: "ticker-search-results",
     };
   }, [
     tickerSearchQuery,
@@ -144,6 +151,7 @@ export default function useTickerSearchModalContent({
     totalTickerResultsPages,
     recentlyViewedSearchResults,
     recentlyViewedSelectedIndex,
+    resultsMode,
   ]);
 
   return {

--- a/src/components/TickerSearchModal/useTickerSearchModalContent.ts
+++ b/src/components/TickerSearchModal/useTickerSearchModalContent.ts
@@ -14,8 +14,7 @@ export type TickerSearchModalContentProps = {
 // TODO: Rename accordingly
 type TickerSearchModalResultsMode = "ticker-search-results" | "bucket-view";
 
-// TODO: Rename accordingly
-type TickerSearchModalContentResponse = {
+type TickerSearchModalResultsResponse = {
   searchQuery: string;
   setSearchQuery: (query: string) => void;
   searchResults: RustServiceTickerSearchResult[];
@@ -31,7 +30,7 @@ type TickerSearchModalContentResponse = {
 
 export default function useTickerSearchModalContent({
   isSearchModalOpen,
-}: TickerSearchModalContentProps): TickerSearchModalContentResponse {
+}: TickerSearchModalContentProps): TickerSearchModalResultsResponse {
   const [recentlyViewedSearchResults, setRecentlyViewedSearchResults] =
     useState<RustServiceTickerSearchResult[]>([]);
   const [recentlyViewedSelectedIndex, setRecentlyViewedSelectedIndex] =
@@ -99,7 +98,7 @@ export default function useTickerSearchModalContent({
     pageSize,
     totalPages,
     resultsMode,
-  } = useMemo<TickerSearchModalContentResponse>(() => {
+  } = useMemo<TickerSearchModalResultsResponse>(() => {
     const common = {
       searchQuery: tickerSearchQuery,
       setSearchQuery: setTickerSearchQuery,

--- a/src/components/TickerSearchModal/useTickerSearchModalContent.ts
+++ b/src/components/TickerSearchModal/useTickerSearchModalContent.ts
@@ -16,6 +16,8 @@ export default function useTickerSearchModalContent({
 }: TickerSearchModalContentProps) {
   const [recentlyViewedSearchResults, setRecentlyViewedSearchResults] =
     useState<RustServiceTickerSearchResult[]>([]);
+  const [recentlyViewedSelectedIndex, setRecentlyViewedSelectedIndex] =
+    useState<number>(-1);
 
   const {
     searchQuery: tickerSearchQuery,
@@ -62,10 +64,11 @@ export default function useTickerSearchModalContent({
 
         setRecentlyViewedSearchResults(recentlyViewedSearchResults);
       });
+    } else {
+      // Reset selected index
+      setRecentlyViewedSelectedIndex(-1);
     }
   }, [isSearchModalOpen, tickerSearchQuery]);
-
-  // TODO: If no search results, show most recently viewed
 
   // Output adapter
   const {
@@ -81,8 +84,8 @@ export default function useTickerSearchModalContent({
     if (!tickerSearchQuery.trim().length) {
       return {
         searchResults: recentlyViewedSearchResults,
-        setSelectedIndex: () => null, // TODO: Handle
-        selectedIndex: 0, // TODO: Handle
+        setSelectedIndex: setRecentlyViewedSelectedIndex,
+        selectedIndex: recentlyViewedSelectedIndex,
         totalSearchResults: recentlyViewedSearchResults.length,
         page: 1,
         setPage: () => null,
@@ -111,8 +114,8 @@ export default function useTickerSearchModalContent({
     setTickerResultsPage,
     setTickerResultsPageSize,
     totalTickerResultsPages,
-    //
     recentlyViewedSearchResults,
+    recentlyViewedSelectedIndex,
   ]);
 
   // TODO: Also return `mode` to show which type of results are being used

--- a/src/components/TickerSearchModal/useTickerSearchModalContent.ts
+++ b/src/components/TickerSearchModal/useTickerSearchModalContent.ts
@@ -57,18 +57,27 @@ export default function useTickerSearchModalContent({
     initialPageSize: 10,
   });
 
-  // TODO: Adapt so this can query different ticker buckets
   useEffect(() => {
     if (isSearchModalOpen && !tickerSearchQuery.trim().length) {
-      const recentlyViewed =
+      const recentlyViewedBucket =
         store.getFirstTickerBucketOfType("recently_viewed");
 
-      setResultsMode("recently_viewed");
+      let altResultsBucket = recentlyViewedBucket;
+
+      if (recentlyViewedBucket?.tickers.length) {
+        setResultsMode("recently_viewed");
+      } else {
+        const tickerTapeBucket =
+          store.getFirstTickerBucketOfType("ticker_tape");
+        setResultsMode("ticker_tape");
+
+        altResultsBucket = tickerTapeBucket;
+      }
 
       const resultsPromise =
-        recentlyViewed?.tickers &&
+        altResultsBucket?.tickers &&
         Promise.allSettled(
-          recentlyViewed.tickers.map((ticker) =>
+          altResultsBucket.tickers.map((ticker) =>
             fetchTickerDetail(ticker.tickerId),
           ),
         );

--- a/src/hooks/useTickerSearch.ts
+++ b/src/hooks/useTickerSearch.ts
@@ -6,7 +6,7 @@ import debounceWithKey from "@utils/debounceWithKey";
 
 import usePagination from "./usePagination";
 
-export type UseSearchProps = {
+export type TickerSearchProps = {
   initialQuery?: string;
   initialOnlyExactMatches: boolean;
   initialPage?: number;
@@ -14,7 +14,7 @@ export type UseSearchProps = {
   initialSelectedIndex?: number;
 };
 
-const DEFAULT_PROPS: Required<UseSearchProps> = {
+const DEFAULT_PROPS: Required<TickerSearchProps> = {
   initialQuery: "",
   initialOnlyExactMatches: false,
   initialPage: 1,
@@ -24,10 +24,10 @@ const DEFAULT_PROPS: Required<UseSearchProps> = {
 
 // TODO: Capture error state
 // TODO: Rename to `useTickerSearch`
-export default function useSearch(
-  props: Partial<UseSearchProps> = DEFAULT_PROPS,
+export default function useTickerSearch(
+  props: Partial<TickerSearchProps> = DEFAULT_PROPS,
 ) {
-  const mergedProps: Required<UseSearchProps> = useMemo(
+  const mergedProps: Required<TickerSearchProps> = useMemo(
     () => ({ ...DEFAULT_PROPS, ...props }),
     [props],
   );

--- a/src/hooks/useTickerSearch.ts
+++ b/src/hooks/useTickerSearch.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { RustServiceTickerSearchResult } from "@utils/callRustService";
 import { searchTickers } from "@utils/callRustService";
+import customLogger from "@utils/customLogger";
 import debounceWithKey from "@utils/debounceWithKey";
 
 import usePagination from "./usePagination";
@@ -23,7 +24,6 @@ const DEFAULT_PROPS: Required<TickerSearchProps> = {
 };
 
 // TODO: Capture error state
-// TODO: Rename to `useTickerSearch`
 export default function useTickerSearch(
   props: Partial<TickerSearchProps> = DEFAULT_PROPS,
 ) {
@@ -111,6 +111,9 @@ export default function useTickerSearch(
               _setTotalSearchResults(total_count);
               setPage(activePage);
               setSelectedIndex(DEFAULT_PROPS.initialSelectedIndex);
+            })
+            .catch((err) => {
+              customLogger.error("Caught error when searching tickers", err);
             })
             .finally(() => {
               _setisLoading(false);

--- a/src/pages/SearchResults/useSearchResultsURLState.ts
+++ b/src/pages/SearchResults/useSearchResultsURLState.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import useSearch from "@hooks/useSearch";
+import useTickerSearch from "@hooks/useTickerSearch";
 import useURLState from "@hooks/useURLState";
 
 import usePageTitleSetter from "@utils/usePageTitleSetter";
@@ -12,7 +12,7 @@ export default function useSearchResultsURLState() {
     setOnlyExactMatches: _setOnlyExactMatches,
     setPage: _setPage,
     ...rest
-  } = useSearch();
+  } = useTickerSearch();
 
   usePageTitleSetter(searchQuery ? `Search results for: ${searchQuery}` : null);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user feedback in the Ticker Search Modal by displaying context-aware messages based on search results.
	- Introduced a new custom hook for managing the state of the Ticker Search Modal, improving functionality and responsiveness.

- **Bug Fixes**
	- Improved pagination logic to ensure it only displays when there is an active search query.

- **Documentation**
	- Added comments to clarify rendering logic in the Ticker Quantity Fields component for better maintainability.

- **Refactor**
	- Updated import statements and logic in the Ticker Search Modal to streamline search result handling and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->