### PR TITLE
Switch home button from `Get Started` to `Continue` depending on state

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -38,11 +38,7 @@ export default function Home() {
               disabled={isSearchModalOpen}
               startIcon={<TrendingUpIcon />}
             >
-              {
-                // TODO: Don't say "Get Started" if already started... ("Continue" maybe?)
-                // (base the determination on if the ticker buckets are their default value?)
-              }
-              {!isSearchModalOpen ? "Get Started" : "You're on your way!"}
+              {store.isFreshSession ? "Get Started" : "Continue"}
             </Button>
           </div>
         </div>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -425,6 +425,23 @@ class _Store extends ReactStateEmitter<StoreStateProps> {
     });
   }
 
+  get isFreshSession() {
+    const recentlyViewedBucket =
+      this.getFirstTickerBucketOfType("recently_viewed");
+
+    if (!recentlyViewedBucket) {
+      // Somehow the user deleted this bucket, so assume not a fresh session
+      return false;
+    }
+
+    if (!recentlyViewedBucket.tickers.length) {
+      // Has not viewed any tickers
+      return true;
+    }
+
+    return false;
+  }
+
   /**
    * Invoked by the `MultiMQTTRoomProvider` to update state of currently subscribed rooms.
    */


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated button text on the Home page to provide a more relevant prompt based on the freshness of the user session.
	- Introduced a new session management feature to evaluate whether the current session is fresh, enhancing user experience.

- **Bug Fixes**
	- Streamlined logic for button text display, improving clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->