### PR TITLE
Add `r2` 10-K vectors

### DIFF
--- a/rust/src/data_models/data_url.rs
+++ b/rust/src/data_models/data_url.rs
@@ -29,10 +29,10 @@ impl DataURL {
             DataURL::ETFAggregateDetailShardIndex => "/data/etf_aggregate_detail_shard_index.enc",
             DataURL::ETFHoldingTickersShardIndex => "/data/etf_holding_tickers_shard_index.enc",
             // DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
-            // DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
-            DataURL::FinancialVectors10K => {
-                "/data/NEW_PROTO_NO_POST_SCALE.financial_vectors.tenk.bin"
-            } // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            // DataURL::FinancialVectors10K => {
+            //     "/data/NEW_PROTO_NO_POST_SCALE.financial_vectors.tenk.bin"
+            // } // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
             // DataURL::FinancialVectors10K => "/data/key_metrics.tenk.bin", // Prototype
             DataURL::Image(_) => panic!("Use image_url() for image paths"), // Prevent calling value() for images
         }

--- a/rust/src/data_models/data_url.rs
+++ b/rust/src/data_models/data_url.rs
@@ -28,8 +28,8 @@ impl DataURL {
             DataURL::TickerETFHoldersShardIndex => "/data/ticker_etf_holders_shard_index.enc",
             DataURL::ETFAggregateDetailShardIndex => "/data/etf_aggregate_detail_shard_index.enc",
             DataURL::ETFHoldingTickersShardIndex => "/data/etf_holding_tickers_shard_index.enc",
-            // DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
-            DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            // DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
             // DataURL::FinancialVectors10K => {
             //     "/data/NEW_PROTO_NO_POST_SCALE.financial_vectors.tenk.bin"
             // } // TODO: Use encoded bin, provided that compression doesn't actually increase the file size

--- a/rust/src/data_models/data_url.rs
+++ b/rust/src/data_models/data_url.rs
@@ -28,11 +28,8 @@ impl DataURL {
             DataURL::TickerETFHoldersShardIndex => "/data/ticker_etf_holders_shard_index.enc",
             DataURL::ETFAggregateDetailShardIndex => "/data/etf_aggregate_detail_shard_index.enc",
             DataURL::ETFHoldingTickersShardIndex => "/data/etf_holding_tickers_shard_index.enc",
-            DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
-            // DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
-            // DataURL::FinancialVectors10K => {
-            //     "/data/NEW_PROTO_NO_POST_SCALE.financial_vectors.tenk.bin"
-            // } // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            // DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            DataURL::FinancialVectors10K => "/data/r2.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
             // DataURL::FinancialVectors10K => "/data/key_metrics.tenk.bin", // Prototype
             DataURL::Image(_) => panic!("Use image_url() for image paths"), // Prevent calling value() for images
         }

--- a/rust/src/data_models/data_url.rs
+++ b/rust/src/data_models/data_url.rs
@@ -28,7 +28,8 @@ impl DataURL {
             DataURL::TickerETFHoldersShardIndex => "/data/ticker_etf_holders_shard_index.enc",
             DataURL::ETFAggregateDetailShardIndex => "/data/etf_aggregate_detail_shard_index.enc",
             DataURL::ETFHoldingTickersShardIndex => "/data/etf_holding_tickers_shard_index.enc",
-            DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            // DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
             // DataURL::FinancialVectors10K => "/data/key_metrics.tenk.bin", // Prototype
             DataURL::Image(_) => panic!("Use image_url() for image paths"), // Prevent calling value() for images
         }

--- a/rust/src/data_models/data_url.rs
+++ b/rust/src/data_models/data_url.rs
@@ -29,7 +29,10 @@ impl DataURL {
             DataURL::ETFAggregateDetailShardIndex => "/data/etf_aggregate_detail_shard_index.enc",
             DataURL::ETFHoldingTickersShardIndex => "/data/etf_holding_tickers_shard_index.enc",
             // DataURL::FinancialVectors10K => "/data/financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
-            DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            // DataURL::FinancialVectors10K => "/data/NEW_PROTO.financial_vectors.tenk.bin", // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
+            DataURL::FinancialVectors10K => {
+                "/data/NEW_PROTO_NO_POST_SCALE.financial_vectors.tenk.bin"
+            } // TODO: Use encoded bin, provided that compression doesn't actually increase the file size
             // DataURL::FinancialVectors10K => "/data/key_metrics.tenk.bin", // Prototype
             DataURL::Image(_) => panic!("Use image_url() for image paths"), // Prevent calling value() for images
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,4 +99,4 @@ interface FileAcceptType {
 export const FILE_IMPORT_ACCEPT_MAP: ReadonlyMap<string, FileAcceptType> =
   new Map([["csv", { extensions: [".csv"], mimeTypes: ["text/csv"] }]]);
 
-export const MAX_CSV_IMPORT_SIZE: number = 1024 * 2;
+export const MAX_CSV_IMPORT_SIZE: number = 1024 * 1024 * 2;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the data source for financial vectors to a new path, improving access to the latest data.
	- Increased the maximum allowable size for CSV imports from 2 KB to 2 MB, enhancing data handling capabilities.

- **Bug Fixes**
	- Corrected the path for the `FinancialVectors10K` variant to ensure accurate data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->