### PR TITLE
Fix ticker adjustment layout issue on narrow viewports

### DIFF
--- a/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.Ticker.tsx
+++ b/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.Ticker.tsx
@@ -19,6 +19,7 @@ import TickerWeightSelector from "./MultiTickerManager.TickerWeightSelector";
 export type MultiTickerManagerTickerProps = {
   adjustedTickerBucket: TickerBucket;
   tickerDetail: RustServiceTickerDetail;
+  isTiling: boolean;
   onSelect: () => void;
   onDeselect: () => void;
   onAdjust: (adjustedTicker: TickerBucketTicker) => void;
@@ -33,6 +34,7 @@ export type MultiTickerManagerTickerProps = {
 export default function MultiTickerManagerTicker({
   adjustedTickerBucket,
   tickerDetail,
+  isTiling,
   onSelect,
   onDeselect,
   onAdjust,
@@ -151,13 +153,13 @@ export default function MultiTickerManagerTicker({
           display: "flex",
           alignItems: "center",
           paddingTop: 1,
-          paddingLeft: 4,
           width: "100%",
         }}
       >
         <Box style={{ width: "100%" }}>
           <TickerWeightSelector
             mx={8}
+            isTiling={isTiling}
             tickerSymbol={tickerBucketTicker?.symbol}
             disabled={isDisabled}
             onChange={(evt, val) => {

--- a/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.TickerWeightSelector.tsx
+++ b/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.TickerWeightSelector.tsx
@@ -98,7 +98,7 @@ export default function TickerWeightSelector({
         sx={{
           display: "flex",
           alignItems: "center",
-          justifyContent: isTiling ? "right" : "left",
+          justifyContent: isTiling ? "flex-end" : "flex-start",
           flexWrap: "wrap",
           gap: 1,
         }}

--- a/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.TickerWeightSelector.tsx
+++ b/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.TickerWeightSelector.tsx
@@ -15,6 +15,7 @@ import useStableCurrentRef from "@hooks/useStableCurrentRef";
 import formatNumberWithCommas from "@utils/string/formatNumberWithCommas";
 
 type TickerWeightSeletorProps = Omit<BoxProps, "onChange"> & {
+  isTiling: boolean;
   min: number;
   max: number;
   onChange: (evt: Event, value: number) => void;
@@ -26,6 +27,7 @@ type TickerWeightSeletorProps = Omit<BoxProps, "onChange"> & {
 };
 
 export default function TickerWeightSelector({
+  isTiling,
   min,
   max,
   onChange,
@@ -96,7 +98,9 @@ export default function TickerWeightSelector({
         sx={{
           display: "flex",
           alignItems: "center",
-          justifyContent: "flex-end",
+          justifyContent: isTiling ? "right" : "left",
+          flexWrap: "wrap",
+          gap: 1,
         }}
       >
         <InputLabel

--- a/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.applet.tsx
+++ b/src/components/TickerBucketViewWindowManager/applets/MultiTickerManager.applet/MultiTickerManager.applet.tsx
@@ -36,6 +36,7 @@ const TICKER_QUANTITY_ADJUST_DEBOUNCE_TIME = 250;
 
 export default function MultiTickerManagerApplet({
   adjustedTickerDetails,
+  isTiling,
   ...rest
 }: MultiTickerManagerAppletProps) {
   const {
@@ -70,6 +71,7 @@ export default function MultiTickerManagerApplet({
   return (
     <TickerBucketViewWindowManagerAppletWrap
       adjustedTickerDetails={adjustedTickerDetails}
+      isTiling={isTiling}
       {...rest}
     >
       <Layout>
@@ -162,6 +164,7 @@ export default function MultiTickerManagerApplet({
                     key={forceRefreshIndex}
                     adjustedTickerBucket={adjustedTickerBucket}
                     tickerDetail={tickerDetail}
+                    isTiling={isTiling}
                     onSelect={() => selectTickerId(tickerDetail.ticker_id)}
                     onDeselect={() => deselectTickerId(tickerDetail.ticker_id)}
                     onAdjust={(adjustedTicker) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `isTiling` property to enhance layout flexibility in the Multi Ticker Manager components.
	- The `TickerWeightSelector` now adjusts its layout based on the `isTiling` prop, improving user experience.

- **Bug Fixes**
	- Enhanced error handling by ensuring adjustments are only made with valid data.

- **Style**
	- Modified layout styles for better visual alignment when in tiled mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->